### PR TITLE
Label missing jira info example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # gitStream-examples
-
 Example PRs that demonstrate gitStream capabilities.
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # gitStream-examples
+
 Example PRs that demonstrate gitStream capabilities.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # gitStream-examples
 Example PRs that demonstrate gitStream capabilities.
+

--- a/Standard/label-missing-jira/app.js
+++ b/Standard/label-missing-jira/app.js
@@ -1,0 +1,1 @@
+// the main app

--- a/Standard/label-missing-jira/app.js
+++ b/Standard/label-missing-jira/app.js
@@ -1,1 +1,2 @@
 // the main app
+console.log('Hello World');


### PR DESCRIPTION
Details here: https://docs.gitstream.cm/automations/label-missing-jira-info/